### PR TITLE
Cata ilabaca/revert commit to add cms entry points

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="eol_contact_form",
-    version="0.2.3",
+    version="0.2.4",
     author="Oficina EOL UChile",
     author_email="eol-ing@uchile.cl",
     description="Eol Contact Form",
@@ -16,9 +16,6 @@ setuptools.setup(
     ],
     entry_points={
         "lms.djangoapp": [
-            "eol_contact_form = eol_contact_form.apps:EolContactFormConfig",
-        ],
-         "cms.djangoapp": [
             "eol_contact_form = eol_contact_form.apps:EolContactFormConfig",
         ]
     },


### PR DESCRIPTION
Se revierte el commit que agregaba el cms para permitir las traducciones como "hack" pues ya no es necesario debido a los cambios de generación de los assets