### PR TITLE
Cata ilabaca/remove explicit language

### DIFF
--- a/eol_contact_form/templates/eol_contact_form/contact.html
+++ b/eol_contact_form/templates/eol_contact_form/contact.html
@@ -5,7 +5,7 @@
 <%namespace name='static' file='/static_content.html'/>
 <%inherit file="../main.html" />
 <%block name="pagetitle">${_("Contact Form")}</%block>
-<script src="https://www.google.com/recaptcha/api.js?explicit&hl=en" async defer></script>
+<script src="https://www.google.com/recaptcha/api.js" async defer></script>
 <link rel="stylesheet" type="text/css" href="${static.url('eol_contact_form/css/main.css')}"/>
 <%
 data = context.get('data', None)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="eol_contact_form",
-    version="0.5.1",
+    version="0.5.2",
     author="Oficina EOL UChile",
     author_email="eol-ing@uchile.cl",
     description="Eol Contact Form",


### PR DESCRIPTION
Se elimina la variable explicit que permite setear un idioma en especifico para que el selector de idioma también cambie el idioma de la frase del recaptcha